### PR TITLE
Implementation dark current and nonlinear correction

### DIFF
--- a/oceanoptics/defines.py
+++ b/oceanoptics/defines.py
@@ -150,30 +150,13 @@ OceanOpticsValidPixels = {
     'HR2000'        : slice(26, 2048),
     }
 
-# TODO: For QE6500 the values in the datasheet were not correct ! (is also wrong in Spectra Suite) -> Please checkfor your model individually
-OceanOpticsDarkPixels = {
-    'Apex'          : [1,2,3,2064,2065,2066,2067],
-    'HR2000+'       : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
-    'HR4000'        : [6,7,8,9,10,11,12,13,14,15,16,17,18],
-    'Maya'          : [1,2,3,2064,2065,2066,2067],
-    'Maya2000pro'   : [1,2,3,2064,2065,2066,2067],
-    'QE65000'       : [1,2,3,1038,1039,1040,1041],
-    'QE65pro'       : [0,1,2,3,1038,1039,1040,1041,1042,1043],
-    'Torus'         : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
-    'USB2000+'      : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
-    'USB4000'       : [6,7,8,9,10,11,12,13,14,15,16,17,18],
-    'USB2000'       : [], #TODO: Add dark pixels
-    'USB650'        : [], #TODO: Add dark pixels
-    'HR2000'        : [], #TODO: Add dark pixels
-	}
-
 OceanOpticsMinMaxIntegrationTime = {
     'Apex'          : (0.015, 1600.),
     'HR2000+'       : (0.001, 655.350),
     'HR4000'        : (0.00001, 655.350),
     'Maya'          : (0.015, 1600.),
     'Maya2000pro'   : (0.0072, 65.),
-    'QE65000'       : (0.0008, 1600.),
+    'QE65000'       : (0.008, 1600.),
     'QE65pro'       : (0.010, 1600.),
     'Torus'         : (0.0, float('inf')),  # TODO: don't know...
     'USB2000+'      : (0.001, 655.350),
@@ -184,6 +167,5 @@ OceanOpticsMinMaxIntegrationTime = {
     'STS'           : (0.00001, 85.)
     }
 
-OceanOpticsSupportedModels = list(OceanOpticsSpectrumConfig.keys()) + ['STS']
-
+OceanOpticsSupportedModels = OceanOpticsSpectrumConfig.keys() + ['STS']
 

--- a/oceanoptics/defines.py
+++ b/oceanoptics/defines.py
@@ -150,13 +150,30 @@ OceanOpticsValidPixels = {
     'HR2000'        : slice(26, 2048),
     }
 
+# TODO: For QE6500 the values in the datasheet were not correct ! (is also wrong in Spectra Suite) -> Please checkfor your model individually
+OceanOpticsDarkPixels = {
+    'Apex'          : [1,2,3,2064,2065,2066,2067],
+    'HR2000+'       : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'HR4000'        : [6,7,8,9,10,11,12,13,14,15,16,17,18],
+    'Maya'          : [1,2,3,2064,2065,2066,2067],
+    'Maya2000pro'   : [1,2,3,2064,2065,2066,2067],
+    'QE65000'       : [1,2,3,1038,1039,1040,1041],
+    'QE65pro'       : [0,1,2,3,1038,1039,1040,1041,1042,1043],
+    'Torus'         : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'USB2000+'      : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'USB4000'       : [6,7,8,9,10,11,12,13,14,15,16,17,18],
+    'USB2000'       : [], #TODO: Add dark pixels
+    'USB650'        : [], #TODO: Add dark pixels
+    'HR2000'        : [], #TODO: Add dark pixels
+	}
+
 OceanOpticsMinMaxIntegrationTime = {
     'Apex'          : (0.015, 1600.),
     'HR2000+'       : (0.001, 655.350),
     'HR4000'        : (0.00001, 655.350),
     'Maya'          : (0.015, 1600.),
     'Maya2000pro'   : (0.0072, 65.),
-    'QE65000'       : (0.008, 1600.),
+    'QE65000'       : (0.0008, 1600.),
     'QE65pro'       : (0.010, 1600.),
     'Torus'         : (0.0, float('inf')),  # TODO: don't know...
     'USB2000+'      : (0.001, 655.350),
@@ -167,5 +184,6 @@ OceanOpticsMinMaxIntegrationTime = {
     'STS'           : (0.00001, 85.)
     }
 
-OceanOpticsSupportedModels = OceanOpticsSpectrumConfig.keys() + ['STS']
+OceanOpticsSupportedModels = list(OceanOpticsSpectrumConfig.keys()) + ['STS']
+
 

--- a/oceanoptics/defines.py
+++ b/oceanoptics/defines.py
@@ -150,6 +150,23 @@ OceanOpticsValidPixels = {
     'HR2000'        : slice(26, 2048),
     }
 
+# TODO: For QE6500 the values in the datasheet were not correct ! (is also wrong in Spectra Suite) -> Please checkfor your model individually
+OceanOpticsDarkPixels = {
+    'Apex'          : [1,2,3,2064,2065,2066,2067],
+    'HR2000+'       : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'HR4000'        : [6,7,8,9,10,11,12,13,14,15,16,17,18],
+    'Maya'          : [1,2,3,2064,2065,2066,2067],
+    'Maya2000pro'   : [1,2,3,2064,2065,2066,2067],
+    'QE65000'       : [1,2,3,1038,1039,1040,1041],
+    'QE65pro'       : [0,1,2,3,1038,1039,1040,1041,1042,1043],
+    'Torus'         : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'USB2000+'      : [12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29],
+    'USB4000'       : [6,7,8,9,10,11,12,13,14,15,16,17,18],
+    'USB2000'       : [], #TODO: Add dark pixels
+    'USB650'        : [], #TODO: Add dark pixels
+    'HR2000'        : [], #TODO: Add dark pixels
+	}
+
 OceanOpticsMinMaxIntegrationTime = {
     'Apex'          : (0.015, 1600.),
     'HR2000+'       : (0.001, 655.350),


### PR DESCRIPTION
Here's some code for the implementation of the dark current and nonlinearity correction.
When using the the dark current correction it is possible that the datasheets are wrong about which pixels can be used, at least that was the case for the QE65000. 